### PR TITLE
Refactor case study for hands-on delivery

### DIFF
--- a/episodes/06_case_study3.md
+++ b/episodes/06_case_study3.md
@@ -44,47 +44,13 @@ Both facilities are heavily subscribed and Hugh tries to maximise his throughput
 times. Workloads on these clusters are submitted to a queue and will start running at an
 unknown time. Almost all of his workloads run for at least 48 hours.
 
-To better understand the emissions related with his work Hugh categorises his activities
-under the GHG protocol.
-
-::::::::::::::::::::::::::::::::::::: challenge
-
-## Identify Scope 2 Emissions
-
-What Scope 2 emissions under the GHG protocol can you identity from Hugh's work?
-
-:::::::::::::::::::::::: solution
-
-- Emissions from electricity usage associated with simulation workloads.
-- Emissions from electricity usage associated with data analysis and visualisation
-  workflows.
-
-:::::::::::::::::::::::::::::::::
-
-:::::::::::::::::::::::::::::::::::::::::::::::
-
-::::::::::::::::::::::::::::::::::::: challenge
-
-## Identify Scope 3 Emissions
-
-What Scope 3 emissions under the GHG protocol can you identity from Hugh's work?
-
-:::::::::::::::::::::::: solution
-
-- Proportional embedded emissions from HPC facilities.
-
-:::::::::::::::::::::::::::::::::
-
-:::::::::::::::::::::::::::::::::::::::::::::::
-
 ## Collecting Information
 
-Hugh starts by doing research some background reasearch about the two clusters he uses.
+Hugh starts by doing some background reasearch about the two clusters he uses.
 
 DRAGONFLY is a cluster based in London. It doesn't publish any sustainability
 information. The documentation pages provide some lists of the available hardware but
-these are fairly high level and don't include specific CPU or server models. Electricity
-for this cluster is backed by renewable energy certificates.
+these are fairly high level and don't include specific CPU or server models.
 
 LANCER is a cluster based in Wales. Its documentation has some dedicated information on
 sustainability including a GHG analysis of the cluster. This includes an embodied
@@ -121,35 +87,144 @@ embodied emissions in his analysis.
 
 ## Analysis
 
+:::::::::::::::::::::::::::::::::: challenge
+
+### Estimating Emissions
+
+Based on the scenario described above how could Hugh estimate the carbon emissions
+associated with his HPC workloads over a year? What additional data would he need to
+collect?
+
+::::::::::::::::::::::::::::::: solution
+
+Hugh needs two things.
+
+1. An estimate of his resource usage over a year. It may be possible to reconstruct this
+   from historical data or he may have to monitor his usage for a period and then
+   extrapolate to annual usage from there. To simplify this he can focus on only his
+   main simulation campaigns and exclude any data analysis workloads. Key data he'll
+   want to track includes CPU-hours and Gb-hours of memory usage.
+1. A method to estimate emissions from his usage. For LANCER this is straightforward
+   using the tooling that's supplied for the cluster. Making an estimate for DRAGONFLY
+   is harder without equivalent tooling. There are several options. Hugh could attempt
+   to use a model like the [Green Algorithms Calculator] if he has sufficient
+   information about the hardware used by DRAGONFLY. A simpler alternative would be to
+   assume that emissions for a given set of resources are the same between DRAGONFLY and
+   LANCER then extrapolate from LANCER emissions estimates to get equivalents for
+   DRAGONFLY. In both cases the estimate for DRAGONFLY is likely to be much more
+   approximate but is still useful to have.
+
+[Green Algorithms Calculator]: https://calculator.green-algorithms.org/
+
+::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::: spoiler
+
+## Hugh's Estimates
+
 For the next two weeks Hugh keeps track of the workloads that he runs on the different
 clusters. He tracks the total CPU-hours spent on different clusters and the different
-simulation codes used on each one.
+simulation codes used on each one. He also gets the total estimated emissions for LANCER
+using the provided cluster tooling.
 
-| Cluster | Simulation Code | Total CPU-hours | Notes |
-| --- | --- | ---: | --- |
-| DRAGONFLY | GROMINZ | 45,000 | Self-compiled |
-| | ORANGE | 30,000 | |
-| | LUMMPS | 20,000 | |
-| LANCER | GROMINZ | 60,000 | Self-compiled |
-| | ORANGE | 40,000 | |
-| | LUMMPS | 75,000 | |
+| Cluster | Simulation Code | Total CPU-hours | Notes | Emissions (kgCO₂e) |
+| --- | --- | ---: | --- | --- |
+| DRAGONFLY | GROMINZ | 45,000 | Self-compiled | |
+| | ORANGE | 30,000 | | |
+| | LUMMPS | 20,000 | | |
+| LANCER | GROMINZ | 60,000 | Self-compiled | 32 |
+| | ORANGE | 40,000 | | 21 |
+| | LUMMPS | 75,000 | | 40 |
 
-Using the calculation tool provided by LANCER Hugh is able to get an estimate of the
-carbon emissions associated with all of his work there. The total amount is 94 kgCO2e.
-Hugh also decides to estimate his emissions from DRAGONFLY by scaling the emissions of
-LANCER by the difference in CPU-hours used on both systems - he's aware that LANCER and
-DRAGONFLY are quite different and so this value for DRAGONFLY is very approximate but
-still thinks it's useful to know. This gives a total of 51 kgCO2e for DRAGONFLY.
+The total estimated emissions are 94 kgCO₂e from the two week period. Scaling . Hugh also
+decides to estimate his emissions from DRAGONFLY by scaling the emissions of LANCER by
+the difference in CPU-hours used on both systems - he's aware that LANCER and DRAGONFLY
+are quite different and so this value for DRAGONFLY is very approximate.
+
+:::::::::::::::::::::::::::::::::: challenge
+
+## Estimating DRAGONFLY emissions
+
+Based on the above approach, estimate the emissions from DRAGONFLY for each of the
+simulation codes.
+
+:::::::::::::::::::::::::::::: solution
+
+Taking GROMINZ as an example:
+
+$$
+Emissions_{DRAGONFLY} = \frac{Resources_{DRAGONFLY}}{Resources_{LANCER}} *
+Emissions_{LANCER} \\
+Emissions_{DRAGONFLY} = \frac{45000 CPUhours}{60000 CPUhours} * 32 kgCO_2e \\
+Emissions_{DRAGONFLY} = 24 kgCO_2e
+$$
+
+Applying this to the other simulation codes gives:
+
+| Cluster | Simulation Code | Total CPU-hours | Notes | Emissions (kgCO₂e) |
+| --- | --- | ---: | --- | --- |
+| DRAGONFLY | GROMINZ | 45,000 | Self-compiled | 24 |
+| | ORANGE | 30,000 | | 16 |
+| | LUMMPS | 20,000 | | 11 |
+| LANCER | GROMINZ | 60,000 | Self-compiled | 32 |
+| | ORANGE | 40,000 | | 21 |
+| | LUMMPS | 75,000 | | 40 |
+
+This gives a total 144 kgCO₂e from the two week period.
+
+:::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::
 
 Whilst collecting the above data Hugh also notes that around 15,000 CPU-hours were wasted
 on workloads that he hadn't setup properly and which had to be repeated. He estimates
-this corresponds to around 8 kgCO2e.
+this corresponds to around 8 kgCO₂e.
 
-Finally Hugh, takes his total emissions figure and tries to better understand what it
-means by comparing with other emissions sources. He finds that arond 145 kgCO2e is
-approximately equivalent to driving for around 500 miles in a petrol fueled car.
+To better understand what this figure means Hugh, takes his total emissions figure from
+the two weeks and compares it with other emissions sources. He finds that 144 kgCO₂e is
+approximately equivalent to driving for around 500 miles in a petrol fueled car^1^.
+
+Scaling the number for two weeks up to a full year, Hugh gets a total of 3.5 TCO₂e. He
+notes that this is close to the UK per-capita emissions for energy generation. This
+means the electricity demands of his work is nearly equivalent to those of whole second
+person.
+
+::::::::::::::::::::::::::::::::::::::::::::
 
 ## Taking Action
+
+:::::::::::::::::::::::::::::::::: challenge
+
+## Planning Action
+
+Based on the outcome of Hugh's data collection and analysis consider the following:
+
+- Where would Hugh derive the most impact to reduce emissions?
+- What steps could Hugh take to reduce the emissions associated with his work? These
+  might be technical or changes to his work practices.
+
+:::::::::::::::::::::::::::::: solution
+
+For focussing his future actions and exploration:
+
+- Hugh spends the most CPU-hours on LANCER.
+- Hugh spends the most CPU-hours using GROMINZ.
+
+The 15,000 wasted CPU-hours are also a good focus as the associated emmisions were
+non-productive.
+
+There are many steps Hugh could take to reduce emissions. Keep a record of the ideas
+you've had and compare them with those in the next section.
+
+:::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::: spoiler
+
+### Hugh Takes Action
 
 Based on the data gathered above Hugh observes:
 
@@ -169,7 +244,7 @@ the simulations he performs and try to reduce the overall amount of simulation.
 
 The 15,000 wasted CPU-hours of simulation are an obvious initial target. Hugh reviews
 the jobs that went wrong and identifies the root causes. He then adjusts his workflows
-to prevent them happening again. To help in the future, he agrees with a member of this
+to prevent them happening again. To help in the future, he agrees with a member of his
 research group that they will double check each others simulation inputs before starting
 significant new simulation projects. With these measures Hugh estimates that he may be
 able to reduce his wasted CPU-hours by half.
@@ -196,9 +271,9 @@ out some performance benchmarking. He runs simulations with all of his simulatio
 across both clusters. Hugh carefully designs these simulations to be short, so as to not
 generate too many emissions, but representative of typical workloads. A key finding he
 identifies is that GROMINZ runs 15% faster on LANCER when using the same number of CPU
-cores. Meanwhile, ORANGE and LUMMPS don't seem to show much difference between the two
-clusters. Hugh realises he can work more efficiently by shifting as much of his work
-using GROMINZ to LANCER as possible.
+cores. Meanwhile, ORANGE and LUMMPS don't show much difference between the two clusters.
+Hugh realises he can work more efficiently by shifting as much of his work using GROMINZ
+to LANCER as possible.
 
 Most of Hugh's simulations require him to run jobs in parallel, using many CPU cores and
 cluster nodes at the same time. Hugh is familiar with the fact that as his jobs use
@@ -211,7 +286,9 @@ computational resources by 20% whilst only losing 10% speed. Hugh resolves to ca
 this sort of benchmarking for all new projects he starts to identify a good trade-off
 between speed and efficiency.
 
-### Outcomes
+::::::::::::::::::::::::::::::::::::::::::::
+
+## Outcomes
 
 Putting all of the above steps together Hugh estimates that he can reduce his overall
 use of CPU-hours by 25% across both clusters. This would result in a saving of ~36 kgCO2
@@ -226,3 +303,10 @@ to make use of Hugh's work.
 Hugh also contacts the team maintaining DRAGONFLY highlighting the utility of tools to
 measure carbon intensity data. The team promises to explore how they can add some more
 functionality to DRAGONFLY.
+
+## References
+
+1. Calculated from an emissions rate of 0.27849 kgCO₂e/mile. This is emissions rate
+   reported for an average car in 2025 by the [UK Government Conversion Factors for
+   greenhouse gases
+   dataset](https://www.gov.uk/government/publications/greenhouse-gas-reporting-conversion-factors-2025).

--- a/episodes/06_case_study3.md
+++ b/episodes/06_case_study3.md
@@ -87,6 +87,20 @@ embodied emissions in his analysis.
 
 ## Analysis
 
+::::::::::::::::::::::::::::::: instructor
+
+Delivery of the rest of this material is intended to go in two phases:
+
+1. Have attendees complete the "Estimating Emissions" challenge. This is best done in
+   groups. Have attendees report back on what they've come up with.
+
+1. Then have attendees open the spoiler tag - "Hugh's estimates". This section provides
+   the "canonical" outcome of Hugh's emissions estimates and further develops the
+   scenario so that reductions in emissions can be considered. Recommend that the groups
+   from above look through the section together and complete the embedded challenge.
+
+::::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::: challenge
 
 ### Estimating Emissions
@@ -138,10 +152,10 @@ using the provided cluster tooling.
 | | ORANGE | 40,000 | | 21 |
 | | LUMMPS | 75,000 | | 40 |
 
-The total estimated emissions are 94 kgCO₂e from the two week period. Scaling . Hugh also
-decides to estimate his emissions from DRAGONFLY by scaling the emissions of LANCER by
-the difference in CPU-hours used on both systems - he's aware that LANCER and DRAGONFLY
-are quite different and so this value for DRAGONFLY is very approximate.
+The total estimated emissions are 94 kgCO₂e from the two week period. Hugh also decides
+to estimate his emissions from DRAGONFLY by scaling the emissions of LANCER by the
+difference in CPU-hours used on both systems - he's aware that LANCER and DRAGONFLY are
+quite different and so this value for DRAGONFLY is very approximate.
 
 :::::::::::::::::::::::::::::::::: challenge
 
@@ -194,6 +208,16 @@ person.
 ::::::::::::::::::::::::::::::::::::::::::::
 
 ## Taking Action
+
+:::::::::::::::::::::::::::::::::: instructor
+
+Similarly to above, the below challenge can be tackled collectively and attendees can
+report back on their results.
+
+The following spoiler section then rounds out the scenario and provides a "canonical"
+outcome. Suggest that the below "outcomes" section is delivered to all attendees.
+
+:::::::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::: challenge
 
@@ -289,6 +313,9 @@ between speed and efficiency.
 ::::::::::::::::::::::::::::::::::::::::::::
 
 ## Outcomes
+
+<!-- markdownlint-disable-next-line line-length -->
+![Carbon emissions from each cluter comparing pre- and post-intervention](fig/case_study3_outcomes.png){alt='A bar chart comparing the emissions from DRAGONFLY and LANCER before and after implementation of emissions reduction measures'}
 
 Putting all of the above steps together Hugh estimates that he can reduce his overall
 use of CPU-hours by 25% across both clusters. This would result in a saving of ~36 kgCO2


### PR DESCRIPTION
This PR restructures Case Study 3 for attendee-led delivery.

The main structure is to add an exercise before each section of the case study that asks attendees to engage with the material and come up with ideas. The case study content is hidden under spoiler tags for them to look through after and compare their suggestions . Attendees are also asked to make some of the calculations throughout.

I've removed the GHG protocol classification exercise as the whole thing is much more hands-on in general and applying the GHG to protocol in individual activities doesn't necessary make sense.