### PR TITLE
Update docker image to v0.2.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   workbench:
-    image: carpentries/workbench-docker:v0.2.2
+    image: carpentries/workbench-docker:v0.2.7
     environment:
       WORKBENCH_PROFILE: "local"
     ports:


### PR DESCRIPTION
@dalonsoa I think this fixes the mermaid diagram issue at least locally. Depending on how it looks once published we might need to upgrade the tool versions used in the workflows.. Heads up for @jamesturner246 @miruuna @SaranjeetKaur this will cause a new large docker image to be downloaded once in your worktree.