### PR TITLE
Case Study 4 edits

### DIFF
--- a/episodes/08_case_study4.md
+++ b/episodes/08_case_study4.md
@@ -1,27 +1,31 @@
 ---
 title: "Case Study 4 - GPU Computing User"
-teaching: 20 # teaching time in minutes
-exercises: 10 # exercise time in minutes
+teaching: 0 # teaching time in minutes
+exercises: 60 # exercise time in minutes
 ---
 
 :::::::::::::::::::::::::::::::::::::: questions
 
-- What are the sustainability considerations related to using heterogeneous computing
-  architectures, including graphical processing units (GPU), tensor cores and other
-  alternative hardware?
-- What are the practical implications for their use in machine learning and general
-  single instruction multiple data (SIMD) computations?
+- How can prior training run data and local benchmark timings be used to estimate the
+  carbon footprint of a new model before committing to a full training run?
+- What is the carbon cost of training a deep learning model naively compared to using
+  optimisations such as transfer learning, mixed precision, and early stopping?
+- How do ML-specific choices — optimiser, batch size, model architecture — affect both
+  GPU memory requirements, utilisation efficiency, and carbon emissions?
+- What are the trade-offs between running training jobs on cloud GPU infrastructure
+  versus a local workstation?
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::: objectives
 
-- Introduce a representative research case study relating to heterogeneous Computing,
-  where GPUs are used to train and deploy a deep leaning artificial neural network
-  (ANN) application.
-- Discuss some general guidelines for estimating your carbon impact using GPU hardware.
-- Consider strategies for reducing carbon impact without sacrificing the benefits of
-  using this class of hardware in machine learning applications.
+- Estimate the carbon footprint of a deep learning training run using proxy data from a
+  previous run and local benchmark timings.
+- Identify sources of wasted computation in a naive model training workflow and
+  prioritise opportunities for reduction.
+- Evaluate the carbon impact of ML optimisations including transfer learning,
+  mixed-precision training, early stopping, and model architecture choices.
+- Compare the carbon cost and practical trade-offs of local versus cloud GPU training.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
@@ -50,7 +54,7 @@ an existing model he deployed last year. The existing model was trained with vas
 quantities of real animal images, and is already quite competent at feline-based image
 processing. It performed simple detection of cats in images, but the new model must
 produce bounding boxes. The previous training script was very crude, and simply passed
-the entire dataset through the model in batches of $256$, for exactly $100$ epochs of
+the entire dataset through the model in batches of 256, for exactly 100 epochs of
 stochastic gradient descent (SGD), with no regularisation.
 
 Based on his experience preparing the previous model, he knows that his workstation's
@@ -58,6 +62,10 @@ GPU will not have enough memory to train the similarly-sized derived model with 
 reasonable batch size in its current form. Like last time, he will aim to offload the
 training of the model to a cloud GPU compute provider, however local development and
 fine-tuning will still be possible using a very small batch size.
+
+Before committing cloud compute resources, Miguel wants to estimate the carbon cost of
+his planned training run and explore ways to reduce it — both to keep emissions low and
+to avoid an expensive wasted run if something goes wrong.
 
 [MLOps]: https://en.wikipedia.org/wiki/MLOps
 [SIMD]: https://en.wikipedia.org/wiki/Single_instruction,_multiple_data
@@ -80,7 +88,7 @@ real-time measurement, prediction tools and extrapolaring from known data.
 
 - Realtime measurement can be performed locally using either a physical meter measuring
   power usage directly from the mains socket, or by wrapping code with power monitoring
-  software packages such as [Code Carbon]. Realtime measurement of cloud jobs may also
+  software packages such as [CodeCarbon]. Realtime measurement of cloud jobs may also
   be possible, since many cloud providers offer infrastructure for querying live energy
   usage of running jobs.
 - Carbon data from training the previous model may be used as surrogate data for the
@@ -90,7 +98,7 @@ real-time measurement, prediction tools and extrapolaring from known data.
   job given its runtime, server location and compute requirements.
 
 [Green Algorithms Calculator]: https://calculator.green-algorithms.org/
-[Code Carbon]: https://github.com/mlco2/codecarbon
+[CodeCarbon]: https://github.com/mlco2/codecarbon
 
 ::::::::::::::::::::::::::::::::::::::::
 
@@ -102,20 +110,21 @@ real-time measurement, prediction tools and extrapolaring from known data.
 
 ### Estimating Emissions (20 minutes)
 
-Miguel computes a few simple estimates up-front to give a rough idea of the carbon
-footprint of a full training run. Using the following information, try to replicate the
-results of Miguel's estimations.
+Miguel uses 2 methods to get estimates up-front of the carbon footprint of a full
+training run.
 
 #### Local Development and Testing
 
-Miguel is unable to train the model at target batch size of $256$ on his workstation,
-but information from a smaller run might still be useful for estimating the carbon
-emissions of the larger run. On his workstation, he times how long it takes to complete
-a single training epoch, using $1\%$ of the training data, with a batch size of $32$.
-The elapsed time comes to $5.76$ hours.
+Miguel is unable to train the model at target batch size of 256 on his workstation, but
+information from a smaller run might still be useful for estimating the carbon emissions
+of the larger run. He decides to use [CodeCarbon] to measure the power consumption of his
+CPU and GPU for a single training epoch, using 1% of the training data, with a batch
+size of 32.
 
-**How might this information help in estimating emissions in the full run? Try forming
-an estimate for carbon emissions of the full run using this information alone.**
+[CodeCarbon] reports an energy usage of 430 Wh over 5 hours during this test run.
+
+**Use this value to estimate the energy required and carbon emissions for a full
+training run.**
 
 #### Previous Training Runs
 
@@ -124,13 +133,20 @@ run of the previous model may be used as surrogate data for estimating the carbo
 of the newer model. He remembers that the previous job ran for approximately 72 hours,
 and used the Azure (Southern UK) datacentre with the following hardware:
 
-- $64$ GB of available host RAM
+- 64 GB of available host RAM
 - Eight virtual cores of an Intel Xeon Platinum 8260 CPU
 - One whole NVIDIA Tesla V100 GPU
 
-**Use the [Green Algorithms Calculator] to estimate the carbon footprint of training the
-new model using information obtained from training the similar previous model. For this
-exercise, select data version `v3.0` in the top right of the calculator page.**
+**Use the [Green Algorithms Calculator] to estimate the energy usage and carbon
+footprint of training the new model using information obtained from training the similar
+previous model. For this exercise, select data version `v3.0` in the top right of the
+calculator page.**
+
+#### Comparing
+
+**Miguel has used two different methods to estimate the power usage of a full training
+run. What would be the strengths and weakness of each method? What additional data would
+help improve the estimates?**
 
 ::::::::::::::::::::::::::::::: solution
 
@@ -138,26 +154,82 @@ Miguel's results for the two estimate methods are as follows.
 
 #### Local Development and Testing
 
-Miguel can use this information to get another rough estimate of the time required to
-completely train the model. Given that only $1\%$ of training data was used, the time
-required for $100\%$ of data would be about $576$ hours. Furthermore, given the batch
-size used in the test was $32$, eight times lower than the target batch size of $256$,
-the time required to train the full model with the final batch size will be around
-$576 / 8 = 72$ hours.
+Since the test run used 1% of the training data, scaling the measured energy up to the
+full dataset gives:
+
+$$
+430 \text{ Wh} \times 100 = 43{,}000 \text{ Wh} = \textbf{43 kWh}
+$$
+
+Using the 2025 UK average carbon intensity of 126 g/kWh this gives a total of 5.4
+kgCO2e.
 
 #### Previous Training Runs
 
-Whilst Miguel does not have actual measurements for carbon emissions whilst training the
-older model, he has enough information to compute an estimate retroactively using, for
-instance, the [Green Energy Calculator]. Plugging in the runtime, hardware and location
-of the job into the calculator, it estimates that $30.55$ kWh of energy was required to
-train the model, with a carbon footprint of $7.06$ kgCO2e.
+Plugging in the runtime, hardware and location of the job into the calculator, it
+estimates that 30.55 kWh of energy was required to train the model, with a carbon
+footprint of 7.06 kgCO2e.
+
+#### Comparing
+
+The two methods give estimates of 43 kWh (5.4 kgCO₂e)and 30.55 kWh (7.06 kgCO₂e), which
+are in rough agreement given the approximations involved. Some differences:
+
+**Energy estimates (43 vs 30.55 kWh):** The local benchmark is likely an overestimate of
+the cloud run's energy consumption. The test run uses a smaller batch size and local
+consumer-grade hardware, both of which tend to be less energy-efficient than the cloud
+data centre's server-grade GPUs. The Green Algorithms Calculator estimate is based on
+component TDP values rather than real utilisation, which tends to overestimate,
+partially offsetting this.
+
+**Carbon intensity (5.4 vs 7.06 kgCO₂e):** The local estimate uses the UK average grid
+intensity (126 gCO₂/kWh), while the Green Algorithms Calculator uses a location- and
+provider-specific value for Azure Southern UK. The latter also applies a PUE factor to
+account for data centre cooling and infrastructure overhead — an overhead not captured
+by [CodeCarbon] on the local workstation.
+
+**Strengths and weaknesses:**
+
+| | Local benchmark (CodeCarbon) | Surrogate data (Green Algorithms Calculator) |
+| :--- | :--- | :--- |
+| Energy measurement | Directly measured (actual power draw) | Estimated from TDP (may over/underestimate) |
+| Hardware match | Different from cloud run | More representative of planned training |
+| Carbon intensity | UK average | Provider- and location-specific |
+| Overheads accounted for | No | Yes |
+| Overall | Good for bounding the estimate; captures real utilisation on local hardware | More representative of the actual cloud run |
+
+**Additional data that would improve both estimates:** real-time carbon intensity at the
+time and location of the run; GPU utilisation metrics from the cloud provider; the data
+centre's actual PUE; and actual energy billing data from the cloud provider if
+available, as some providers now expose this directly.
+
+Given the above, the surrogate data estimate of (7.06 kgCO₂e) is the more representative
+figure for the planned cloud training run, as long as it's run in the same location, and
+we'll use it as the baseline going forward.
 
 ::::::::::::::::::::::::::::::::::::::::
 
 :::::::::::::::::::::::::::::::::::::::::::::::
 
 ## Taking Action
+
+:::::::::::::::::::::::::::::::::::::: challenge
+
+### Reducing emissions from model training (20 minutes)
+
+Miguel's estimates suggest that a naive training run — repeating the same approach used
+for the previous model — would cost approximately **7.06 kgCO₂e**. In your groups,
+discuss what strategies Miguel could use to reduce this. Consider:
+
+- Are there any aspects of the naive training approach that represent unnecessary
+  computation?
+- What ML-specific techniques could reduce the number of training steps required?
+- What are the trade-offs between training on a cloud GPU versus a local workstation,
+  from both a carbon and a practical perspective?
+
+:::::::::::::::::::::::::::::: solution
+
+### Miguel Takes Action
 
 From his observations, Miguel formulates a plan. It is clear to him that it is entirely
 unnecessary to train a new model from scratch, given the prior model is already quite
@@ -197,16 +269,11 @@ increased, he adds logic to terminate early once the model's loss function conve
 The 32-bit floating-point numbers for activation state and gradients are switched to
 16-bit, increasing operator speed and halving the memory required for both.
 
-Based on experience on similar jobs, Miguel expects at least a 15x increase in training
-speed on similar hardware. Plugging the new runtime estimate of 10 hours into the
-[Green Algorithms Calculator], his new estimated energy usage is $4.24$ kWh, with a
-carbon footprint of $0.98$ kgCO2e from these changes alone.
-
 Miguel takes another look at the model's architecture, and notes that it is very large
 for its stated purpose, with many channels per convolutional layer, and very wide fully
-connected layers in the head. He Miguel wonders if the model can be pruned to enable
-training on his workstation, instead of relying on the cloud provider. Noting again that
-the model is very large for its stated purpose, Miguel adds L1 (Lasso) regularisation to
+connected layers in the head. He wonders if the model can be pruned to enable training
+on his workstation, instead of relying on the cloud provider. Noting again that the
+model is very large for its stated purpose, Miguel adds L1 (Lasso) regularisation to
 reduce redundant activation, allowing many (now-unused) activation units to be removed
 from the model entirely, resulting in a $20\%$ memory saving.
 
@@ -232,16 +299,58 @@ the same hardware.
 
 These experiments highlight the dramatic computational efficiency increases that can
 be achieved with careful optimisation of the job. Naive implementation of training and
-inference can have a considerably higher carbon foorprint, requiring larger GPUs and
+inference can have a considerably higher carbon footprint, requiring larger GPUs and
 longer run times, while carefully optimised workflows can be run very quickly and be
 small enough to run on local hardware.
 
 It can often be the case that running AI workflows on cloud providers has a smaller
-carbon foorprint than running on local hardware. The energy efficiency measures of
+carbon footprint than running on local hardware. The energy efficiency measures of
 datacentres make operational carbon relatively lower than smaller dedicated hardware
-setups, and embedded carbon can be lower using existing datacentre hardware, compared
-to buying and decommissioning in-house hardware. The flipside is that one looses the
-ability to choose when a job is executed, meaning demmand shifting to off-peak times
-is no longer an option. In either case, Miguel's optimisations have had a huge effect
-on the model's carbon footprint, and have afforded him the *choice* of using either,
+setups, and embedded carbon can be lower using existing datacentre hardware, compared to
+buying and decommissioning in-house hardware. The flipside is that one looses the
+ability to choose when a job is executed, meaning demand shifting to off-peak times is
+no longer an option. In either case, Miguel's optimisations have had a huge effect on
+the model's carbon footprint, and have afforded him the *choice* of using either,
 depending on the circumstances.
+
+:::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::
+
+## Outcomes
+
+After completing his optimisations Miguel runs some more tests and finds an 83%
+reduction in computation time running on the same hardware. He uses this factor to
+estimate the carbon savings of training his models in the cloud.
+
+![Carbon emissions for model training comparing the naive approach and Miguel's
+optimised approach](fig/case_study4_outcomes.png){alt='A bar chart comparing the carbon
+emissions from a naive full training run against the optimised approach using transfer
+learning, mixed precision, early stopping, and model pruning'}
+
+The table below summarises the key changes Miguel made:
+
+| | **Naive approach** | **Optimised approach** |
+| :--- | :--- | :--- |
+| Training strategy | From scratch (100 epochs, full dataset) | Transfer learning + early stopping |
+| Optimiser | SGD | Adam with learning rate decay |
+| Numerical precision | FP32 throughout | Mixed precision (FP32/FP16) |
+| Estimated power consumption (cloud) | 30.55 kWh | 5.3 kWh |
+| Carbon footprint (kgCO₂e) | **7.06** | **1.22** |
+
+::::::::::::::::::::::::::::::::::::: keypoints
+
+- Prior training run data and local benchmark timings can be combined to estimate
+  emissions before committing to an expensive full training run.
+- Naive ML training workflows often contain significant avoidable computation — training
+  from scratch when transfer learning is possible is a common and costly example.
+- ML-specific optimisations (transfer learning, early stopping, mixed precision, model
+  pruning) can reduce both training time and GPU memory requirements, often by an order
+  of magnitude.
+- Maximising GPU utilisation through right-sized batch sizes improves energy efficiency;
+  a partially-occupied GPU is disproportionately less efficient than a fully-occupied one.
+- Cloud training offers lower operational carbon through data centre efficiency but
+  removes the option to demand-shift; local training restores that flexibility at the
+  cost of higher embodied emissions per unit of compute.
+
+::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
A few bits and pieces changed:
- Updated the estimating emissions exercise. Previously the local runs was only focused on a time estimate and it wasn't clear how it was useful towards getting a carbon estimate. Swapped it to using CodeCarbon to power/emissions estimate for local runs. This sets up a nice compare and contrast exercise for the local vs cloud estimate using green algorithms.
- Restructured the taking action section into an exercise.
- Added a outcomes section for consistency with other case studies.
- Updated questions, key points etc based on this.